### PR TITLE
Adapted to WSA based on Android 12.1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,17 @@
 .externalNativeBuild
 .cxx
 local.properties
+*.apk
+*.ap_
+*.aab
+*.dex
+*.class
+bin/
+gen/
+Thumbs.db
+.idea
+build/
+.navigation
+captures/
+output.json
+obj/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,13 +68,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    namespace = "org.lsposed.wsa.helper"
 }
 
 dependencies {
     implementation("androidx.compose.ui:ui:$composeVersion")
-    implementation("androidx.compose.material3:material3:1.0.0-alpha02")
+    implementation("androidx.compose.material3:material3:1.0.0-alpha12")
     implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
     implementation("androidx.activity:activity-compose:1.4.0")
-    implementation("com.google.accompanist:accompanist-drawablepainter:0.21.4-beta")
+    implementation("com.google.accompanist:accompanist-drawablepainter:0.23.1")
     debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.lsposed.wsa.helper">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"

--- a/app/src/main/java/org/lsposed/wsa/helper/MainActivity.kt
+++ b/app/src/main/java/org/lsposed/wsa/helper/MainActivity.kt
@@ -16,7 +16,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val installReceiver: BroadcastReceiver? = getWSAInstallReceiver(this)
         setContent {
             val colorScheme = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 if (isSystemInDarkTheme())
@@ -28,11 +27,12 @@ class MainActivity : ComponentActivity() {
             MaterialTheme(
                 colorScheme = colorScheme
             ) {
+                val installReceiver: BroadcastReceiver? = getWSAInstallReceiver(this)
                 if (installReceiver == null || (applicationInfo.flags or ApplicationInfo.FLAG_SYSTEM) == 0) {
                     AlertDialog(
                         onDismissRequest = { finish() },
                         title = {
-                            Text("Failed to initialized")
+                            Text("Failed to initialized\ninstallReceiver=$installReceiver")
                         },
                         confirmButton = {}
                     )

--- a/app/src/main/java/org/lsposed/wsa/helper/WSAUtils.kt
+++ b/app/src/main/java/org/lsposed/wsa/helper/WSAUtils.kt
@@ -17,8 +17,10 @@ fun getWSAInstallReceiver(context: Context) = runCatching {
     val ctor = handlerClass.getConstructor(Context::class.java)
     ctor.newInstance(object : ContextWrapper(context) {
         fun onRegister(receiver: BroadcastReceiver?, filter: IntentFilter) {
-            Log.d(TAG, "skip receiver")
-            if (filter.hasAction(Intent.ACTION_PACKAGE_ADDED) && receiver != null) {
+            Log.d(TAG, "skip receiver, filter: ${filter.actionsIterator().next()}")
+            if ((filter.hasAction(Intent.ACTION_PACKAGE_ADDED) ||
+                        filter.hasAction("com.microsoft.windows.app.packageinstall.INTENT_PACKAGE_UNINSTALL_COMMIT")) && receiver != null
+            ) {
                 installReceiver = receiver
                 Log.i(TAG, "got install receiver")
             }

--- a/app/src/main/java/org/lsposed/wsa/helper/WSAUtils.kt
+++ b/app/src/main/java/org/lsposed/wsa/helper/WSAUtils.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import dalvik.system.PathClassLoader
 
 private var installReceiver: BroadcastReceiver? = null
+const val TAG: String = "LSPosed WSA Helper"
 
 fun getWSAInstallReceiver(context: Context) = runCatching {
     if (installReceiver != null) return@runCatching installReceiver
@@ -16,10 +17,10 @@ fun getWSAInstallReceiver(context: Context) = runCatching {
     val ctor = handlerClass.getConstructor(Context::class.java)
     ctor.newInstance(object : ContextWrapper(context) {
         fun onRegister(receiver: BroadcastReceiver?, filter: IntentFilter) {
-            Log.d("LSPosed", "skip receiver")
+            Log.d(TAG, "skip receiver")
             if (filter.hasAction(Intent.ACTION_PACKAGE_ADDED) && receiver != null) {
                 installReceiver = receiver
-                Log.i("LSPosed", "got install receiver")
+                Log.i(TAG, "got install receiver")
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    val composeVersion by extra("1.1.0-rc01")
+    val composeVersion by extra("1.2.0-beta02")
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0")
+        classpath("com.android.tools.build:gradle:7.2.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.0")
+        classpath("com.android.tools.build:gradle:7.2.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Dec 17 21:37:10 CST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/stub/build.gradle.kts
+++ b/stub/build.gradle.kts
@@ -48,6 +48,7 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+    namespace = "org.lsposed.wsa.helper"
 }
 
 dependencies {

--- a/stub/src/main/AndroidManifest.xml
+++ b/stub/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="org.lsposed.wsa.helper"
     android:persistent="true"
     android:usesNonSdkApi="true">
 


### PR DESCRIPTION
`W/BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.PACKAGE_REPLACED dat=package:org.lsposed.wsa.helper flg=0x4000010 (has extras) } to com.microsoft.launcher/com.microsoft.mmx.continuity.receiver.InstallUninstallReceiver`